### PR TITLE
fix: 参考情報のリンクを平文からクリック可能なリンクに変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,8 +180,8 @@
       <div class="summary-card">
         <h3>参考資料・リンク</h3>
         <ul>
-          <li>日本歯科医学会：口腔機能低下症に関する基本的な考え方</li>
-          <li>日本老年歯科医学会：公式ホームページ</li>
+          <li><a href="https://www.jads.or.jp/basic_idea/index.html" target="_blank" rel="noopener noreferrer">日本歯科医学会：口腔機能低下症に関する基本的な考え方</a></li>
+          <li><a href="https://www.gerodontology.jp/" target="_blank" rel="noopener noreferrer">日本老年歯科医学会：公式ホームページ</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
- 日本歯科医学会と日本老年歯科医学会のリンクを実際のURLに更新
- セキュリティのためtarget=_blank rel=noopener noreferrerを追加
- ユーザビリティの向上により医療従事者の情報アクセスが改善

Fixes #21