### PR TITLE
Potential fix for code scanning alert no. 20: Code injection

### DIFF
--- a/.github/workflows/claude-code-response-superclaude.yml
+++ b/.github/workflows/claude-code-response-superclaude.yml
@@ -106,6 +106,7 @@ jobs:
         if: steps.event-check.outputs.should_process == 'true'
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
           echo "=== Claude OAuth APIを使用した応答生成 ==="
           
@@ -124,7 +125,7 @@ jobs:
 
           # Issue情報の取得
           issue_body = """${{ github.event.issue.body }}"""
-          issue_title = """${{ github.event.issue.title }}"""
+          issue_title = os.environ.get('ISSUE_TITLE', '')
           issue_number = "${{ github.event.issue.number }}"
 
           # Claude OAuth API エンドポイント


### PR DESCRIPTION
Potential fix for [https://github.com/h4mmerjp/oral-function-firebase/security/code-scanning/20](https://github.com/h4mmerjp/oral-function-firebase/security/code-scanning/20)

To fix the issue, the value of `${{ github.event.issue.title }}` should not be embedded directly in the script source via in-place interpolation but should instead be set as an environment variable for the step. The script should then retrieve this value using `os.environ`. This isolates the untrusted input and prevents breaking out of string context even if the data contains special characters.

**How to perform the fix:**
- In the workflow file, within the step definition, add a new `env:` key-value pair, e.g., `ISSUE_TITLE: ${{ github.event.issue.title }}`.
- In the Python script, remove the direct interpolation and instead retrieve via `issue_title = os.environ.get('ISSUE_TITLE', '')`.
- Do the same for any other similar fields like `issue_body` if necessary (for best practice).

**Where to change:**
- In `.github/workflows/claude-code-response-superclaude.yml`, step "ステップ6: Claude OAuth APIを使用した応答生成", 
  - Add a new `ISSUE_TITLE` (and optionally `ISSUE_BODY`, `ISSUE_NUMBER`) environment variable(s) to `env:`.
  - Change the Python script so that `issue_title = ...` uses `os.environ`.

**Imports/Definitions:**  
No new imports are necessary, as `os.environ` is already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
