### PR TITLE
Potential fix for code scanning alert no. 22: Code injection

### DIFF
--- a/.github/workflows/claude-code-response-superclaude.yml
+++ b/.github/workflows/claude-code-response-superclaude.yml
@@ -107,6 +107,7 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           echo "=== Claude OAuth APIを使用した応答生成 ==="
           
@@ -124,7 +125,7 @@ jobs:
               sys.exit(1)
 
           # Issue情報の取得
-          issue_body = """${{ github.event.issue.body }}"""
+          issue_body = os.environ.get('ISSUE_BODY', '')
           issue_title = os.environ.get('ISSUE_TITLE', '')
           issue_number = "${{ github.event.issue.number }}"
 


### PR DESCRIPTION
Potential fix for [https://github.com/h4mmerjp/oral-function-firebase/security/code-scanning/22](https://github.com/h4mmerjp/oral-function-firebase/security/code-scanning/22)

The correct fix is to avoid direct use of `${{ github.event.issue.body }}` within the script. Instead, set an environment variable (e.g., `ISSUE_BODY`) at the step level to `${{ github.event.issue.body }}`. Inside the script, access the value from the environment using safe methods (`os.environ["ISSUE_BODY"]`). This approach allows the shell to pass the value safely as an environment variable, so py-script input is not expanded into the Python code and cannot break out of the intended quotation context; user input is handled strictly as a data value, not as part of the code.  
All changes are confined to step 6, around lines 127. Remove the problematic line and ensure `ISSUE_BODY` is set; then, in Python, use `os.environ["ISSUE_BODY"]` instead of the interpolated value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
